### PR TITLE
Ignore spred attribute

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -190,6 +190,10 @@ module.exports = function (_ref) {
                   var attrs = jsxOpeningElementPath.node.attributes;
                   var componentAttrs = {};
                   attrs.map(function (attr) {
+                    if (attr.type === 'JSXSpreadAttribute') {
+                      return;
+                    }
+                    
                     if (["colorScheme", "variant", "size"].includes(attr.name.name)) {
                       componentAttrs[attr.name.name] = attr.value.value;
                     }


### PR DESCRIPTION
Spread attribute don't have `name.name` .